### PR TITLE
Use `TTimeStamp` and make `RawHeader.h` more similar to `raw_data.h`

### DIFF
--- a/LinkDef.h
+++ b/LinkDef.h
@@ -62,52 +62,52 @@
   source = " std::vector<double> volts[208]; "\
   code = "{ int iin = 0; for (int i = 0; i < 208; i++) { std::copy(onfile.volts[iin].begin(), onfile.volts[iin].end(), volts[i].begin()); iin++; }}"
 
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  include = "cstdint" \
-  target = " \
-event_second,\
-readout_time,\
-event_number,\
-L2_mask,\
-trig_type,\
-event_time,\
-last_pps,\
-llast_pps,\
-deadtime_counter,\
-deadtime_counter_last_pps,\
-deadtime_counter_llast_pps\
-  " \
-  version =  "[2]" \
-  source = "\
-Int_t run;\
-UInt_t triggerTime;\
-UInt_t readoutTime;\
-UInt_t readoutTimeNs;\
-ULong_t eventNumber;\
-UInt_t L2Mask;\
-UInt_t trigType;\
-UInt_t trigTime;\
-UInt_t lastPPS;\
-UInt_t lastLastPPS;\
-UShort_t deadTime;\
-UShort_t deadTimeLastPPS;\
-UShort_t deadTimeLastLastPPS;\
-  "\
-  code = "{\
-newObj->run = (uint32_t) onfile.run;\
-event_second = (int32_t) onfile.triggerTime;\
-readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);\
-event_number = static_cast<uint32_t>(onfile.eventNumber); \
-L2_mask = static_cast<uint32_t>(onfile.L2Mask);\
-trig_type = static_cast<uint32_t>(onfile.trigType);\
-event_time = static_cast<uint32_t>(onfile.trigTime);\
-last_pps = static_cast<uint32_t>(onfile.lastPPS);\
-llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);\
-deadtime_counter = static_cast<uint32_t>(onfile.deadTime);\
-deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);\
-deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);\
+#pragma read                                                                            \
+  targetClass = "pueo::RawHeader"                                                       \
+  sourceClass = "pueo::RawHeader"                                                       \
+  include = "cstdint"                                                                   \
+  target = "                                                                            \
+    event_second,                                                                       \
+    readout_time,                                                                       \
+    event_number,                                                                       \
+    L2_mask,                                                                            \
+    trig_type,                                                                          \
+    event_time,                                                                         \
+    last_pps,                                                                           \
+    llast_pps,                                                                          \
+    deadtime_counter,                                                                   \
+    deadtime_counter_last_pps,                                                          \
+    deadtime_counter_llast_pps                                                          \
+  "                                                                                     \
+  version =  "[2]"                                                                      \
+  source = "                                                                            \
+    Int_t run;                                                                          \
+    UInt_t triggerTime;                                                                 \
+    UInt_t readoutTime;                                                                 \
+    UInt_t readoutTimeNs;                                                               \
+    ULong_t eventNumber;                                                                \
+    UInt_t L2Mask;                                                                      \
+    UInt_t trigType;                                                                    \
+    UInt_t trigTime;                                                                    \
+    UInt_t lastPPS;                                                                     \
+    UInt_t lastLastPPS;                                                                 \
+    UShort_t deadTime;                                                                  \
+    UShort_t deadTimeLastPPS;                                                           \
+    UShort_t deadTimeLastLastPPS;                                                       \
+  "                                                                                     \
+  code = "{                                                                             \
+    newObj->run = (uint32_t) onfile.run;                                                \
+    event_second = (int32_t) onfile.triggerTime;                                        \
+    readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);       \
+    event_number = static_cast<uint32_t>(onfile.eventNumber);                           \
+    L2_mask = static_cast<uint32_t>(onfile.L2Mask);                                     \
+    trig_type = static_cast<uint32_t>(onfile.trigType);                                 \
+    event_time = static_cast<uint32_t>(onfile.trigTime);                                \
+    last_pps = static_cast<uint32_t>(onfile.lastPPS);                                   \
+    llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);                              \
+    deadtime_counter = static_cast<uint32_t>(onfile.deadTime);                          \
+    deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);          \
+    deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);     \
   }"
 
 #else

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -62,52 +62,52 @@
   source = " std::vector<double> volts[208]; "\
   code = "{ int iin = 0; for (int i = 0; i < 208; i++) { std::copy(onfile.volts[iin].begin(), onfile.volts[iin].end(), volts[i].begin()); iin++; }}"
 
-#pragma read                                                                            \
-  targetClass = "pueo::RawHeader"                                                       \
-  sourceClass = "pueo::RawHeader"                                                       \
-  include = "cstdint"                                                                   \
-  target = "                                                                            \
-    event_second,                                                                       \
-    readout_time,                                                                       \
-    event_number,                                                                       \
-    L2_mask,                                                                            \
-    trig_type,                                                                          \
-    event_time,                                                                         \
-    last_pps,                                                                           \
-    llast_pps,                                                                          \
-    deadtime_counter,                                                                   \
-    deadtime_counter_last_pps,                                                          \
-    deadtime_counter_llast_pps                                                          \
-  "                                                                                     \
-  version =  "[2]"                                                                      \
-  source = "                                                                            \
-    Int_t run;                                                                          \
-    UInt_t triggerTime;                                                                 \
-    UInt_t readoutTime;                                                                 \
-    UInt_t readoutTimeNs;                                                               \
-    ULong_t eventNumber;                                                                \
-    UInt_t L2Mask;                                                                      \
-    UInt_t trigType;                                                                    \
-    UInt_t trigTime;                                                                    \
-    UInt_t lastPPS;                                                                     \
-    UInt_t lastLastPPS;                                                                 \
-    UShort_t deadTime;                                                                  \
-    UShort_t deadTimeLastPPS;                                                           \
-    UShort_t deadTimeLastLastPPS;                                                       \
-  "                                                                                     \
-  code = "{                                                                             \
-    newObj->run = (uint32_t) onfile.run;                                                \
-    event_second = (int32_t) onfile.triggerTime;                                        \
-    readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);       \
-    event_number = static_cast<uint32_t>(onfile.eventNumber);                           \
-    L2_mask = static_cast<uint32_t>(onfile.L2Mask);                                     \
-    trig_type = static_cast<uint32_t>(onfile.trigType);                                 \
-    event_time = static_cast<uint32_t>(onfile.trigTime);                                \
-    last_pps = static_cast<uint32_t>(onfile.lastPPS);                                   \
-    llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);                              \
-    deadtime_counter = static_cast<uint32_t>(onfile.deadTime);                          \
-    deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);          \
-    deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);     \
+#pragma read                                                                                     \
+  targetClass = "pueo::RawHeader"                                                                \
+  sourceClass = "pueo::RawHeader"                                                                \
+  include = "cstdint"                                                                            \
+  target = "                                                                                     \
+    event_second,                                                                                \
+    readout_time,                                                                                \
+    event_number,                                                                                \
+    L2_mask,                                                                                     \
+    trig_type,                                                                                   \
+    event_time,                                                                                  \
+    last_pps,                                                                                    \
+    llast_pps,                                                                                   \
+    deadtime_counter,                                                                            \
+    deadtime_counter_last_pps,                                                                   \
+    deadtime_counter_llast_pps                                                                   \
+  "                                                                                              \
+  version =  "[2]"                                                                               \
+  source = "                                                                                     \
+    Int_t    run;                                                                                \
+    UInt_t   triggerTime;                                                                        \
+    UInt_t   readoutTime;                                                                        \
+    UInt_t   readoutTimeNs;                                                                      \
+    ULong_t  eventNumber;                                                                        \
+    UInt_t   L2Mask;                                                                             \
+    UInt_t   trigType;                                                                           \
+    UInt_t   trigTime;                                                                           \
+    UInt_t   lastPPS;                                                                            \
+    UInt_t   lastLastPPS;                                                                        \
+    UShort_t deadTime;                                                                           \
+    UShort_t deadTimeLastPPS;                                                                    \
+    UShort_t deadTimeLastLastPPS;                                                                \
+  "                                                                                              \
+  code = "{                                                                                      \
+    newObj->run                = static_cast<uint32_t>(onfile.run);                              \
+    event_second               = static_cast<int32_t>(onfile.triggerTime);                       \
+    readout_time               = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);  \
+    event_number               = static_cast<uint32_t>(onfile.eventNumber);                      \
+    L2_mask                    = static_cast<uint32_t>(onfile.L2Mask);                           \
+    trig_type                  = static_cast<uint32_t>(onfile.trigType);                         \
+    event_time                 = static_cast<uint32_t>(onfile.trigTime);                         \
+    last_pps                   = static_cast<uint32_t>(onfile.lastPPS);                          \
+    llast_pps                  = static_cast<uint32_t>(onfile.lastLastPPS);                      \
+    deadtime_counter           = static_cast<uint32_t>(onfile.deadTime);                         \
+    deadtime_counter_last_pps  = static_cast<uint32_t>(onfile.deadTimeLastPPS);                  \
+    deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);              \
   }"
 
 #else

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -79,13 +79,6 @@
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
-  target = "event_second" \
-  version =  "[2]" \
-  source = "UInt_t triggerTime;"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
   target = "readout_time" \
   version =  "[2]" \
   source = "UInt_t readoutTime; UInt_t readoutTimeNs;"\

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -131,21 +131,21 @@
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter" \
   version =  "[2]" \
-  source = "UShort_T deadTime;"
+  source = "UShort_t deadTime;"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter_last_pps" \
   version =  "[2]" \
-  source = "UShort_T deadTimeLastPPS;"
+  source = "UShort_t deadTimeLastPPS;"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter_llast_pps" \
   version =  "[2]" \
-  source = "UShort_T deadTimeLastLastPPS;"
+  source = "UShort_t deadTimeLastLastPPS;"
 
 #else
 #error "for compilation"

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -65,97 +65,48 @@
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
-  target = "run" \
+  include = "cstdint" \
+  target = " \
+event_second,\
+readout_time,\
+event_number,\
+L2_mask,\
+trig_type,\
+event_time,\
+last_pps,\
+llast_pps,\
+deadtime_counter,\
+deadtime_counter_last_pps,\
+deadtime_counter_llast_pps\
+  " \
   version =  "[2]" \
-  source = "Int_t run;"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "event_second" \
-  version =  "[2]" \
-  source = "UInt_t triggerTime;"\
-  code = "{event_second = (int32_t) onfile.triggerTime;}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "readout_time" \
-  version =  "[2]" \
-  source = "UInt_t readoutTime; UInt_t readoutTimeNs;"\
-  code="{readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "event_number" \
-  version =  "[2]" \
-  source = "ULong_t eventNumber;" \
-  code = "{event_number = static_cast<uint32_t>(onfile.eventNumber);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "L2_mask" \
-  version =  "[2]" \
-  source = "UInt_t L2Mask;"\
-  code = "{L2_mask = static_cast<uint32_t>(onfile.L2Mask);}"
-  
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "trig_type" \
-  version =  "[2]" \
-  source = "UInt_t trigType;"\
-  code = "{trig_type = static_cast<uint32_t>(onfile.trigType);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "event_time" \
-  version =  "[2]" \
-  source = "UInt_t trigTime;"\
-  code = "{event_time = static_cast<uint32_t>(onfile.trigTime);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "last_pps" \
-  version =  "[2]" \
-  source = "UInt_t lastPPS;" \
-  code = "{last_pps = static_cast<uint32_t>(onfile.lastPPS);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "llast_pps" \
-  version =  "[2]" \
-  source = "UInt_t lastLastPPS;" \
-  code = "{llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "deadtime_counter" \
-  version =  "[2]" \
-  source = "UShort_t deadTime;"\
-  code = "{deadtime_counter = static_cast<uint32_t>(onfile.deadTime);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "deadtime_counter_last_pps" \
-  version =  "[2]" \
-  source = "UShort_t deadTimeLastPPS;"\
-  code = "{deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);}"
-
-#pragma read \
-  targetClass = "pueo::RawHeader"\
-  sourceClass = "pueo::RawHeader"\
-  target = "deadtime_counter_llast_pps" \
-  version =  "[2]" \
-  source = "UShort_t deadTimeLastLastPPS;"\
-  code = "{deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);}"
+  source = "\
+UInt_t triggerTime;\
+UInt_t readoutTime;\
+UInt_t readoutTimeNs;\
+ULong_t eventNumber;\
+UInt_t L2Mask;\
+UInt_t trigType;\
+UInt_t trigTime;\
+UInt_t lastPPS;\
+UInt_t lastLastPPS;\
+UShort_t deadTime;\
+UShort_t deadTimeLastPPS;\
+UShort_t deadTimeLastLastPPS;\
+  "\
+  code = "{\
+event_second = (int32_t) onfile.triggerTime;\
+readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);\
+event_number = static_cast<uint32_t>(onfile.eventNumber); \
+L2_mask = static_cast<uint32_t>(onfile.L2Mask);\
+trig_type = static_cast<uint32_t>(onfile.trigType);\
+event_time = static_cast<uint32_t>(onfile.trigTime);\
+last_pps = static_cast<uint32_t>(onfile.lastPPS);\
+llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);\
+deadtime_counter = static_cast<uint32_t>(onfile.deadTime);\
+deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);\
+deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);\
+  }"
 
 #else
 #error "for compilation"

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -74,7 +74,8 @@
   sourceClass = "pueo::RawHeader"\
   target = "event_second" \
   version =  "[2]" \
-  source = "UInt_t triggerTime;"
+  source = "UInt_t triggerTime;"\
+  code = "{event_second = (int32_t) onfile.triggerTime;}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
@@ -89,63 +90,72 @@
   sourceClass = "pueo::RawHeader"\
   target = "event_number" \
   version =  "[2]" \
-  source = "ULong_t eventNumber;"
+  source = "ULong_t eventNumber;" \
+  code = "{event_number = static_cast<uint32_t>(onfile.eventNumber);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "L2_mask" \
   version =  "[2]" \
-  source = "UInt_t L2Mask;"
-
+  source = "UInt_t L2Mask;"\
+  code = "{L2_mask = static_cast<uint32_t>(onfile.L2Mask);}"
+  
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "trig_type" \
   version =  "[2]" \
-  source = "UInt_t trigType;"
+  source = "UInt_t trigType;"\
+  code = "{trig_type = static_cast<uint32_t>(onfile.trigType);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "event_time" \
   version =  "[2]" \
-  source = "UInt_t trigTime;"
+  source = "UInt_t trigTime;"\
+  code = "{event_time = static_cast<uint32_t>(onfile.trigTime);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "last_pps" \
   version =  "[2]" \
-  source = "UInt_t lastPPS;"
+  source = "UInt_t lastPPS;" \
+  code = "{last_pps = static_cast<uint32_t>(onfile.lastPPS);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "llast_pps" \
   version =  "[2]" \
-  source = "UInt_t lastLastPPS;"
+  source = "UInt_t lastLastPPS;" \
+  code = "{llast_pps = static_cast<uint32_t>(onfile.lastLastPPS);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter" \
   version =  "[2]" \
-  source = "UShort_t deadTime;"
+  source = "UShort_t deadTime;"\
+  code = "{deadtime_counter = static_cast<uint32_t>(onfile.deadTime);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter_last_pps" \
   version =  "[2]" \
-  source = "UShort_t deadTimeLastPPS;"
+  source = "UShort_t deadTimeLastPPS;"\
+  code = "{deadtime_counter_last_pps = static_cast<uint32_t>(onfile.deadTimeLastPPS);}"
 
 #pragma read \
   targetClass = "pueo::RawHeader"\
   sourceClass = "pueo::RawHeader"\
   target = "deadtime_counter_llast_pps" \
   version =  "[2]" \
-  source = "UShort_t deadTimeLastLastPPS;"
+  source = "UShort_t deadTimeLastLastPPS;"\
+  code = "{deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);}"
 
 #else
 #error "for compilation"

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -81,6 +81,7 @@ deadtime_counter_llast_pps\
   " \
   version =  "[2]" \
   source = "\
+Int_t run;\
 UInt_t triggerTime;\
 UInt_t readoutTime;\
 UInt_t readoutTimeNs;\
@@ -95,6 +96,7 @@ UShort_t deadTimeLastPPS;\
 UShort_t deadTimeLastLastPPS;\
   "\
   code = "{\
+newObj->run = (uint32_t) onfile.run;\
 event_second = (int32_t) onfile.triggerTime;\
 readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);\
 event_number = static_cast<uint32_t>(onfile.eventNumber); \

--- a/LinkDef.h
+++ b/LinkDef.h
@@ -62,6 +62,97 @@
   source = " std::vector<double> volts[208]; "\
   code = "{ int iin = 0; for (int i = 0; i < 208; i++) { std::copy(onfile.volts[iin].begin(), onfile.volts[iin].end(), volts[i].begin()); iin++; }}"
 
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "run" \
+  version =  "[2]" \
+  source = "Int_t run;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "event_second" \
+  version =  "[2]" \
+  source = "UInt_t triggerTime;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "event_second" \
+  version =  "[2]" \
+  source = "UInt_t triggerTime;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "readout_time" \
+  version =  "[2]" \
+  source = "UInt_t readoutTime; UInt_t readoutTimeNs;"\
+  code="{readout_time = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);}"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "event_number" \
+  version =  "[2]" \
+  source = "ULong_t eventNumber;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "L2_mask" \
+  version =  "[2]" \
+  source = "UInt_t L2Mask;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "trig_type" \
+  version =  "[2]" \
+  source = "UInt_t trigType;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "event_time" \
+  version =  "[2]" \
+  source = "UInt_t trigTime;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "last_pps" \
+  version =  "[2]" \
+  source = "UInt_t lastPPS;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "llast_pps" \
+  version =  "[2]" \
+  source = "UInt_t lastLastPPS;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "deadtime_counter" \
+  version =  "[2]" \
+  source = "UShort_T deadTime;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "deadtime_counter_last_pps" \
+  version =  "[2]" \
+  source = "UShort_T deadTimeLastPPS;"
+
+#pragma read \
+  targetClass = "pueo::RawHeader"\
+  sourceClass = "pueo::RawHeader"\
+  target = "deadtime_counter_llast_pps" \
+  version =  "[2]" \
+  source = "UShort_T deadTimeLastLastPPS;"
 
 #else
 #error "for compilation"

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -210,7 +210,7 @@ pueo::nav::Attitude * pueo::Dataset::gps(bool force_load)
     if (fGpsDirty || force_load)
     {
       //try one that matches realtime
-      int gpsEntry = fGpsTree->GetEntryNumberWithBestIndex(round(header()->triggerTime + header()->triggerTimeNs  / 1e9)); 
+      int gpsEntry = fGpsTree->GetEntryNumberWithBestIndex(round(header()->corrected_trigger_time.GetSec() + header()->corrected_trigger_time.GetNanoSec()  / 1e9)); 
 //      int offset = 0; 
       fGpsTree->GetEntry(gpsEntry); 
       /*
@@ -256,7 +256,7 @@ pueo::RawHeader * pueo::Dataset::header(bool force_load)
 
 
   if(theStrat & kInsertedVPolEvents){
-    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kVertical, fHeader->eventNumber);
+    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kVertical, fHeader->event_number);
     if(fakeTreeEntry > -1){
       overwriteHeader(fHeader, pol::kVertical, fakeTreeEntry);
     }
@@ -264,7 +264,7 @@ pueo::RawHeader * pueo::Dataset::header(bool force_load)
 
 
   if(theStrat & kInsertedHPolEvents){
-    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kHorizontal, fHeader->eventNumber);
+    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kHorizontal, fHeader->event_number);
     if(fakeTreeEntry > -1){
       overwriteHeader(fHeader, pol::kHorizontal, fakeTreeEntry);
     }
@@ -373,7 +373,7 @@ int pueo::Dataset::getEntry(int entryNumber)
     if (fDecimated)
     {
       fDecimatedHeadTree->GetEntry(fDecimatedEntry); 
-      fWantedEntry = fHeadTree->GetEntryNumberWithIndex(fHeader->eventNumber); 
+      fWantedEntry = fHeadTree->GetEntryNumberWithIndex(fHeader->event_number); 
 
     }
     if (!fHaveUsefulFile) fUsefulDirty = true; 
@@ -382,7 +382,7 @@ int pueo::Dataset::getEntry(int entryNumber)
 
 
   // use the header to set the PUEO version 
-  version::setVersionFromUnixTime(header()->triggerTime); 
+  version::setVersionFromUnixTime(header()->corrected_trigger_time.GetSec()); 
 
   return fDecimated ? fDecimatedEntry : fWantedEntry; 
 }
@@ -717,7 +717,7 @@ int pueo::Dataset::previousMinBiasEvent()
       fIndex = N() - 1;
     }
     fHeadTree->GetEntry(fIndex);
-    if((fHeader->trigType&1) == 0) break;
+    if((fHeader->trig_type&1) == 0) break;
   }
   
   return nthEvent(fIndex);
@@ -739,7 +739,7 @@ int pueo::Dataset::nextMinBiasEvent()
       fIndex = 0;
     }
     fHeadTree->GetEntry(fIndex);
-    if((fHeader->trigType&1) == 0) break;
+    if((fHeader->trig_type&1) == 0) break;
   }
   
   return nthEvent(fIndex);
@@ -1136,7 +1136,7 @@ void pueo::Dataset::loadHiCalGps(char which) {
  * @param altitude hical position
  */
 void pueo::Dataset::hiCal(char which, Double_t& longitude, Double_t& latitude, Double_t& altitude) {
-  UInt_t realTime = fHeader ? fHeader->triggerTime : 0;
+  UInt_t realTime = fHeader ? fHeader->corrected_trigger_time.GetSec() : 0;
   hiCal(which, realTime, longitude, latitude, altitude);
 }
 
@@ -1200,16 +1200,14 @@ void pueo::Dataset::overwriteHeader(RawHeader* header, pol::pol_t pol, Int_t fak
   }
 
   // Retain some of the header data for camouflage
-  UInt_t realTime = header->triggerTime;
-  UInt_t triggerTimeNs = header->triggerTimeNs;
-  UInt_t eventNumber = header->eventNumber;
+  TTimeStamp trigger_time = header->corrected_trigger_time;
+  UInt_t event_number = header->event_number;
   Int_t run = header->run;
 
   (*header) = (*fBlindHeader[pol]);
 
-  header->triggerTime = realTime;
-  header->triggerTimeNs = triggerTimeNs;
-  header->eventNumber = eventNumber;
+  header->corrected_trigger_time = trigger_time;
+  header->event_number = event_number;
   header->run = run;
 
 }

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -393,7 +393,7 @@ int pueo::Dataset::getEvent(int eventNumber, bool quiet)
 
   int entry  =  (fDecimated ? fDecimatedHeadTree : fHeadTree)->GetEntryNumberWithIndex(eventNumber); 
 
-  if (entry < 0 && (eventNumber < fHeadTree->GetMinimum("eventNumber") || eventNumber > fHeadTree->GetMaximum("eventNumber")))
+  if (entry < 0 && (eventNumber < fHeadTree->GetMinimum("event_number") || eventNumber > fHeadTree->GetMaximum("event_number")))
   {
       if (!quiet) fprintf(stderr,"WARNING: event %lld not found in header tree\n", fWantedEntry); 
       if (fDecimated) 
@@ -502,7 +502,7 @@ bool  pueo::Dataset::loadRun(int run, DataDirectory dir, bool dec)
       filesToClose.push_back(f); 
       fDecimatedHeadTree = (TTree*) f->Get("headTree"); 
       if (!fDecimatedHeadTree) fDecimatedHeadTree = (TTree*) f->Get("headerTree");
-      fDecimatedHeadTree->BuildIndex("eventNumber"); 
+      fDecimatedHeadTree->BuildIndex("event_number"); 
       fDecimatedHeadTree->SetBranchAddress("header",&fHeader); 
       fIndices = ((TTreeIndex*) fDecimatedHeadTree->GetTreeIndex())->GetIndex(); 
     }
@@ -548,7 +548,7 @@ bool  pueo::Dataset::loadRun(int run, DataDirectory dir, bool dec)
 
   if (!fDecimated) fHeadTree->SetBranchAddress("header",&fHeader); 
 
-  fHeadTree->BuildIndex("eventNumber"); 
+  fHeadTree->BuildIndex("event_number"); 
 
   if (!fDecimated) fIndices = ((TTreeIndex*) fHeadTree->GetTreeIndex())->GetIndex(); 
 
@@ -1009,8 +1009,8 @@ int pueo::Dataset::getRunAtTime(double t)
                 run_info  ri; 
                 ri.run = run; 
                 //TODO do this to nanosecond precision 
-                ri.start_time= t->GetMinimum("triggerTime"); 
-                ri.stop_time = t->GetMaximum("triggerTime") + 1; 
+                ri.start_time= t->GetMinimum("event_second"); 
+                ri.stop_time = t->GetMaximum("event_second") + 1; 
                 run_times[version].push_back(ri); 
               }
             }

--- a/src/RawHeader.cc
+++ b/src/RawHeader.cc
@@ -41,8 +41,8 @@ pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs):
   deadtime_counter_llast_pps(wfs->deadtime_counter_llast_pps),
   L2_mask(wfs->L2_mask),
   readout_time((time_t)wfs->readout_time.utc_secs, wfs->readout_time.utc_nsecs),
-  corrected_readout_time(0,0), // cannot know this without post-processing, so initialize to year 1970
-  corrected_trigger_time(0,0)  // cannot know this without post-processing, so initialize to year 1970
+  corrected_readout_time((time_t)0, 0), // cannot know this without post-processing, so initialize to year 1970
+  corrected_trigger_time((time_t)0, 0)  // cannot know this without post-processing, so initialize to year 1970
 {
   if (wfs->soft_trigger) trig_type |= pueo::trigger::kSoft;
   if (wfs->pps_trigger) trig_type |= pueo::trigger::kPPS0;

--- a/src/RawHeader.cc
+++ b/src/RawHeader.cc
@@ -23,10 +23,10 @@
 
 #include "pueo/RawHeader.h" 
 
-// int pueo::RawHeader::isInPhiMask(int phi, pueo::pol::pol_t pol) const
-// {
-//   return phi_trig_mask[pol] & ( 1 << phi); 
-// }
+int pueo::RawHeader::isInPhiMask(int phi, pueo::pol::pol_t pol) const
+{
+  return phi_trig_mask[pol] & ( 1 << phi); 
+}
 
 #ifdef HAVE_PUEORAWDATA
 pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs):

--- a/src/RawHeader.cc
+++ b/src/RawHeader.cc
@@ -21,41 +21,33 @@
 *
 ****************************************************************************************/ 
 
-
-
 #include "pueo/RawHeader.h" 
 
-
-
-int pueo::RawHeader::isInPhiMask(int phi, pueo::pol::pol_t pol) const
-{
-  return phiTrigMask[pol] & ( 1 << phi); 
-}
-
+// int pueo::RawHeader::isInPhiMask(int phi, pueo::pol::pol_t pol) const
+// {
+//   return phi_trig_mask[pol] & ( 1 << phi); 
+// }
 
 #ifdef HAVE_PUEORAWDATA
-pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs)
-  : run(wfs->run), 
-  triggerTime(wfs->event_second),
-  readoutTime(wfs->readout_time.utc_secs),
-  readoutTimeNs(wfs->readout_time.utc_nsecs),
-  eventNumber(wfs->event),
-  trigTime(wfs->event_time),
-  lastPPS(wfs->last_pps),
-  lastLastPPS(wfs->llast_pps),
-  deadTime(wfs->deadtime_counter),
-  deadTimeLastPPS(wfs->deadtime_counter_last_pps),
-  deadTimeLastLastPPS(wfs->deadtime_counter_llast_pps)
-
+pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs):
+  run(wfs->run), 
+  event_number(wfs->event),
+  event_second(wfs->event_second),
+  event_time(wfs->event_time),
+  last_pps(wfs->last_pps),
+  llast_pps(wfs->llast_pps),
+  deadtime_counter(wfs->deadtime_counter),
+  deadtime_counter_last_pps(wfs->deadtime_counter_last_pps),
+  deadtime_counter_llast_pps(wfs->deadtime_counter_llast_pps),
+  L2_mask(wfs->L2_mask),
+  readout_time((time_t)wfs->readout_time.utc_secs, wfs->readout_time.utc_nsecs),
+  corrected_trigger_time(0,0) // cannot know this without post-processing, so initialize to year 1970
 {
-  if (wfs->soft_trigger) trigType |= pueo::trigger::kSoft;
-  if (wfs->pps_trigger) trigType |= pueo::trigger::kPPS0;
-  if (wfs->ext_trigger) trigType |= pueo::trigger::kExt;
-  if (wfs->L2_mask) trigType |= pueo::trigger::kRFMI;
-  L2Mask = wfs->L2_mask;
+  if (wfs->soft_trigger) trig_type |= pueo::trigger::kSoft;
+  if (wfs->pps_trigger) trig_type |= pueo::trigger::kPPS0;
+  if (wfs->ext_trigger) trig_type |= pueo::trigger::kExt;
+  if (wfs->L2_mask) trig_type |= pueo::trigger::kRFMI;
 
   //TODO convert L2 mask ,L1 mask as needed
-
 }
-
 #endif

--- a/src/RawHeader.cc
+++ b/src/RawHeader.cc
@@ -41,7 +41,8 @@ pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs):
   deadtime_counter_llast_pps(wfs->deadtime_counter_llast_pps),
   L2_mask(wfs->L2_mask),
   readout_time((time_t)wfs->readout_time.utc_secs, wfs->readout_time.utc_nsecs),
-  corrected_trigger_time(0,0) // cannot know this without post-processing, so initialize to year 1970
+  corrected_readout_time(0,0), // cannot know this without post-processing, so initialize to year 1970
+  corrected_trigger_time(0,0)  // cannot know this without post-processing, so initialize to year 1970
 {
   if (wfs->soft_trigger) trig_type |= pueo::trigger::kSoft;
   if (wfs->pps_trigger) trig_type |= pueo::trigger::kPPS0;

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -46,9 +46,9 @@ public:
   // Initialize all timestamps to a clearly garbage value (year 1970).
   // Otherwise ROOT will initialize them to the current time and that's not a good obvious garbage value
   RawHeader():
-    readout_time(0,0),
-    corrected_readout_time(0,0),
-    corrected_trigger_time(0,0)
+    readout_time((time_t)0,0),
+    corrected_readout_time((time_t)0,0),
+    corrected_trigger_time((time_t)0,0)
   {;}
 
 #ifdef HAVE_PUEORAWDATA

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -23,9 +23,10 @@
 #ifndef PUEO_RAW_HEADER_H
 #define PUEO_RAW_HEADER_H
 
-//Includes
-#include "Rtypes.h"
 #include "pueo/Conventions.h"
+#include "TTimeStamp.h"
+#include "Rtypes.h"
+#include <cstdint>
 
 #ifdef HAVE_PUEORAWDATA
 #include "pueo/rawdata.h"
@@ -38,44 +39,57 @@
 
 namespace pueo
 {
-  class RawHeader
-  {
-     public:
-     RawHeader() {;} ///< Default constructor
+class RawHeader
+{
+public:
+  RawHeader():readout_time(0,0),corrected_trigger_time(0,0){;} ///< Default constructor
 
 #ifdef HAVE_PUEORAWDATA
-     RawHeader(const pueo_full_waveforms_t * wfs);
+  RawHeader(const pueo_full_waveforms_t * wfs);
 #endif
-     Int_t           run = 0 ; ///< Run number, assigned on ground
-     UInt_t          triggerTime= 0 ; ///< from the DAQ, may be correct or not
-     UInt_t          triggerTimeNs= 0;
-     UInt_t          readoutTime = 0 ; ///< unixTime of readout
-     UInt_t          readoutTimeNs= 0 ; ///< sub second time of readout
-     ULong_t         eventNumber = 0 ; ///< Software event number
-     UInt_t          L2Mask = {0};
-     UInt_t          phiTrigMask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF)
-     UInt_t          flags = 0; 
+  int32_t   run = -999; ///< Run number, assigned on ground
+  int32_t   event_number = -999;
 
+  /* An example:
 
-     UInt_t        trigType = 0; /// set pueo::trigger namespace in Conventions
-     UInt_t        trigTime = 0; ///< Trigger time in TURF clock ticks
-     UInt_t        lastPPS = 0; ///< Number of TURF clock ticks between GPS pulse per seconds
-     UInt_t        lastLastPPS = 0; ///< Number of TURF clock ticks between GPS pulse per seconds
+            `last_pps`-------+       +-------- `event_time`
+                             ↓       ↓      
+     0--------125E6--------250E6-----o--375E6--------500E6--------625E6-------->
+     |                               |                                    [TURF clock ticks]
+  Run Start                       trigger!
+     |                               |                                    [sec]
+    111--------112----------113----------114----------115----------116---------->
+                             ↑
+          `event_second` ----+        
 
+  */
+  int32_t    event_second = 0; ///< Originally a uint32_t in libpueorawdata but int32_t is okay before year 2038
+                               ///< Value can be wrong prior to post-processing.
 
-     UShort_t        deadTime = 0;
-     UShort_t        deadTimeLastPPS = 0;
-     UShort_t        deadTimeLastLastPPS = 0;
+  uint32_t   event_time = 0; ///< 32-bit free running TURF clock value very briefly after trigger.
+  uint32_t   last_pps = 0; ///< TURF clock value at `event_second`. Value can be wrong prior to post-processing.
+  uint32_t   llast_pps = 0; ///< ... one second prior, value can be wrong, won't be corrected
+  uint32_t   deadtime_counter = 0; ///< @todo: no idea what these are, need help documenting
+  uint32_t   deadtime_counter_last_pps = 0;
+  uint32_t   deadtime_counter_llast_pps = 0;
+  uint32_t   L2_mask = 0;
+  uint32_t   trig_type = 0; ///< soft, pps, or ext trigger (see also pueo::trigger in Conventions.h)
+  TTimeStamp readout_time; ///< Time since Unix epoch [sec]
+                           ///< Tagged by the flight computer upon packet creation (ie event reception)
 
-     UChar_t         L1Octants[k::NUM_SURF_SLOTS] ={0};
+  TTimeStamp corrected_trigger_time; ///< correction via post-processing with pueo::Timemark
+                                     ///< second: from (corrected) `event_second`
+                                     ///< nanosecond: from `event_time` and (corrected) `last_pps`
 
-     // Trigger info
-     int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask
+  // uint32_t  flags = 0; @todo: not popuated
+  // uint32_t  phi_trigMask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) @todo: not populated
+  // UChar_t   L1Octants[k::NUM_SURF_SLOTS] ={0}; @todo not populated
 
+  // Trigger info
+  // int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask
 
-    ClassDefNV(RawHeader,3);
-
-  };
+  ClassDefNV(RawHeader,4);
+};
 }
 
 

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -42,7 +42,14 @@ namespace pueo
 class RawHeader
 {
 public:
-  RawHeader():readout_time(0,0),corrected_trigger_time(0,0){;} ///< Default constructor
+  // Default constructor:
+  // Initialize all timestamps to a clearly garbage value (year 1970).
+  // Otherwise ROOT will initialize them to the current time and that's not a good obvious garbage value
+  RawHeader():
+    readout_time(0,0),
+    corrected_readout_time(0,0),
+    corrected_trigger_time(0,0)
+  {;}
 
 #ifdef HAVE_PUEORAWDATA
   RawHeader(const pueo_full_waveforms_t * wfs);
@@ -77,6 +84,7 @@ public:
   TTimeStamp readout_time; ///< Time since Unix epoch [sec]
                            ///< Tagged by the flight computer upon packet creation (ie event reception)
 
+  TTimeStamp corrected_readout_time; ///< correction via post-processing (method TBD)
   TTimeStamp corrected_trigger_time; ///< correction via post-processing with pueo::Timemark
                                      ///< second: from (corrected) `event_second`
                                      ///< nanosecond: from `event_time` and (corrected) `last_pps`

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -89,12 +89,14 @@ public:
                                      ///< second: from (corrected) `event_second`
                                      ///< nanosecond: from `event_time` and (corrected) `last_pps`
 
-  // uint32_t  flags = 0; @todo: not popuated
-  // uint32_t  phi_trig_mask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) @todo: not populated
-  // UChar_t   L1_octants[k::NUM_SURF_SLOTS] ={0}; @todo not populated
+  uint32_t  flags = 0; /// @todo: not implemented yet (2026Apr2)
+  uint8_t   L1_octants[k::NUM_SURF_SLOTS] ={0}; ///< @todo not implemented yet (2026Apr2)
+  uint32_t  phi_trig_mask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) 
+                                              ///< @note: not quite the same as L2_mask
+                                              ///< @todo: not implemented yet (2026Apr2)
 
   // Trigger info
-  // int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask
+  int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask
 
   ClassDefNV(RawHeader,4);
 };

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -82,8 +82,8 @@ public:
                                      ///< nanosecond: from `event_time` and (corrected) `last_pps`
 
   // uint32_t  flags = 0; @todo: not popuated
-  // uint32_t  phi_trigMask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) @todo: not populated
-  // UChar_t   L1Octants[k::NUM_SURF_SLOTS] ={0}; @todo not populated
+  // uint32_t  phi_trig_mask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) @todo: not populated
+  // UChar_t   L1_octants[k::NUM_SURF_SLOTS] ={0}; @todo not populated
 
   // Trigger info
   // int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -47,8 +47,8 @@ public:
 #ifdef HAVE_PUEORAWDATA
   RawHeader(const pueo_full_waveforms_t * wfs);
 #endif
-  int32_t   run = -999; ///< Run number, assigned on ground
-  int32_t   event_number = -999;
+  uint32_t   run = 0; ///< Run number, assigned on ground
+  uint32_t   event_number = 0;
 
   /* An example:
 

--- a/src/pueo/Timemark.h
+++ b/src/pueo/Timemark.h
@@ -1,7 +1,7 @@
 #ifndef PUEO_TIMEMARK_H
 #define PUEO_TIMEMARK_H
-#include "Rtypes.h"
 #include "TTimeStamp.h"
+#include <cstdint>
 
 #ifdef HAVE_PUEORAWDATA
 #include "pueo/rawdata.h"
@@ -13,14 +13,14 @@ namespace pueo
   class Timemark
   {
   public:
-    Timemark(){;}
+    Timemark(): readout_time(0,0), rising(0,0), falling(0,0){;}
 
     TTimeStamp readout_time;
     TTimeStamp rising;
     TTimeStamp falling;
-    UInt_t rise_count;
-    UInt_t channel;
-    UInt_t flags;
+    uint16_t rise_count=0;
+    uint8_t channel=0;
+    uint8_t flags=0;
 
     ClassDefNV(Timemark, 2); // non virual ClassDef, see https://root-forum.cern.ch/t/classdef-variants/44736/6
 

--- a/src/pueo/Timemark.h
+++ b/src/pueo/Timemark.h
@@ -22,7 +22,10 @@ namespace pueo
     uint8_t channel=0;
     uint8_t flags=0;
 
-    ClassDefNV(Timemark, 2); // non virual ClassDef, see https://root-forum.cern.ch/t/classdef-variants/44736/6
+    int32_t run=-999;          ///< not in raw data, but should be identifiable via post processing
+    int32_t event_number=-999; ///< not in raw data, but should be identifiable via post processing
+
+    ClassDefNV(Timemark, 3); // non virtual ClassDef, see https://root-forum.cern.ch/t/classdef-variants/44736/6
 
 #ifdef HAVE_PUEORAWDATA
     Timemark(const pueo_timemark_t *tmrk):

--- a/src/pueo/Timemark.h
+++ b/src/pueo/Timemark.h
@@ -22,8 +22,8 @@ namespace pueo
     uint8_t channel=0;
     uint8_t flags=0;
 
-    int32_t run=-999;          ///< not in raw data, but should be identifiable via post processing
-    int32_t event_number=-999; ///< not in raw data, but should be identifiable via post processing
+    uint32_t run=0;          ///< not in raw data, but should be identifiable via post processing
+    uint32_t event_number=0; ///< not in raw data, but should be identifiable via post processing
 
     ClassDefNV(Timemark, 3); // non virtual ClassDef, see https://root-forum.cern.ch/t/classdef-variants/44736/6
 


### PR DESCRIPTION
- Use `TTimeStamp` as suggested.
- Make the variable names and types of `RawHeader.h` more similar as they appear in `libpueorawdata`'s `rawdata.h`
- Made corresponding changes downstream in [pueoSim](https://github.com/PUEOCollaboration/pueoSim/pull/106)