### PR TITLE
Revert RawHeader fields back to camelcase

### DIFF
--- a/LinkDef.h
+++ b/LinkDef.h
@@ -62,54 +62,6 @@
   source = " std::vector<double> volts[208]; "\
   code = "{ int iin = 0; for (int i = 0; i < 208; i++) { std::copy(onfile.volts[iin].begin(), onfile.volts[iin].end(), volts[i].begin()); iin++; }}"
 
-#pragma read                                                                                     \
-  targetClass = "pueo::RawHeader"                                                                \
-  sourceClass = "pueo::RawHeader"                                                                \
-  include = "cstdint"                                                                            \
-  target = "                                                                                     \
-    event_second,                                                                                \
-    readout_time,                                                                                \
-    event_number,                                                                                \
-    L2_mask,                                                                                     \
-    trig_type,                                                                                   \
-    event_time,                                                                                  \
-    last_pps,                                                                                    \
-    llast_pps,                                                                                   \
-    deadtime_counter,                                                                            \
-    deadtime_counter_last_pps,                                                                   \
-    deadtime_counter_llast_pps                                                                   \
-  "                                                                                              \
-  version =  "[2]"                                                                               \
-  source = "                                                                                     \
-    Int_t    run;                                                                                \
-    UInt_t   triggerTime;                                                                        \
-    UInt_t   readoutTime;                                                                        \
-    UInt_t   readoutTimeNs;                                                                      \
-    ULong_t  eventNumber;                                                                        \
-    UInt_t   L2Mask;                                                                             \
-    UInt_t   trigType;                                                                           \
-    UInt_t   trigTime;                                                                           \
-    UInt_t   lastPPS;                                                                            \
-    UInt_t   lastLastPPS;                                                                        \
-    UShort_t deadTime;                                                                           \
-    UShort_t deadTimeLastPPS;                                                                    \
-    UShort_t deadTimeLastLastPPS;                                                                \
-  "                                                                                              \
-  code = "{                                                                                      \
-    newObj->run                = static_cast<uint32_t>(onfile.run);                              \
-    event_second               = static_cast<int32_t>(onfile.triggerTime);                       \
-    readout_time               = TTimeStamp((time_t) onfile.readoutTime, onfile.readoutTimeNs);  \
-    event_number               = static_cast<uint32_t>(onfile.eventNumber);                      \
-    L2_mask                    = static_cast<uint32_t>(onfile.L2Mask);                           \
-    trig_type                  = static_cast<uint32_t>(onfile.trigType);                         \
-    event_time                 = static_cast<uint32_t>(onfile.trigTime);                         \
-    last_pps                   = static_cast<uint32_t>(onfile.lastPPS);                          \
-    llast_pps                  = static_cast<uint32_t>(onfile.lastLastPPS);                      \
-    deadtime_counter           = static_cast<uint32_t>(onfile.deadTime);                         \
-    deadtime_counter_last_pps  = static_cast<uint32_t>(onfile.deadTimeLastPPS);                  \
-    deadtime_counter_llast_pps = static_cast<uint32_t>(onfile.deadTimeLastLastPPS);              \
-  }"
-
 #else
 #error "for compilation"
 #endif

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -256,7 +256,7 @@ pueo::RawHeader * pueo::Dataset::header(bool force_load)
 
 
   if(theStrat & kInsertedVPolEvents){
-    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kVertical, fHeader->event_number);
+    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kVertical, fHeader->eventNumber);
     if(fakeTreeEntry > -1){
       overwriteHeader(fHeader, pol::kVertical, fakeTreeEntry);
     }
@@ -264,7 +264,7 @@ pueo::RawHeader * pueo::Dataset::header(bool force_load)
 
 
   if(theStrat & kInsertedHPolEvents){
-    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kHorizontal, fHeader->event_number);
+    Int_t fakeTreeEntry = needToOverwriteEvent(pol::kHorizontal, fHeader->eventNumber);
     if(fakeTreeEntry > -1){
       overwriteHeader(fHeader, pol::kHorizontal, fakeTreeEntry);
     }
@@ -373,7 +373,7 @@ int pueo::Dataset::getEntry(int entryNumber)
     if (fDecimated)
     {
       fDecimatedHeadTree->GetEntry(fDecimatedEntry); 
-      fWantedEntry = fHeadTree->GetEntryNumberWithIndex(fHeader->event_number); 
+      fWantedEntry = fHeadTree->GetEntryNumberWithIndex(fHeader->eventNumber); 
 
     }
     if (!fHaveUsefulFile) fUsefulDirty = true; 
@@ -393,7 +393,7 @@ int pueo::Dataset::getEvent(int eventNumber, bool quiet)
 
   int entry  =  (fDecimated ? fDecimatedHeadTree : fHeadTree)->GetEntryNumberWithIndex(eventNumber); 
 
-  if (entry < 0 && (eventNumber < fHeadTree->GetMinimum("event_number") || eventNumber > fHeadTree->GetMaximum("event_number")))
+  if (entry < 0 && (eventNumber < fHeadTree->GetMinimum("eventNumber") || eventNumber > fHeadTree->GetMaximum("eventNumber")))
   {
       if (!quiet) fprintf(stderr,"WARNING: event %lld not found in header tree\n", fWantedEntry); 
       if (fDecimated) 
@@ -502,7 +502,7 @@ bool  pueo::Dataset::loadRun(int run, DataDirectory dir, bool dec)
       filesToClose.push_back(f); 
       fDecimatedHeadTree = (TTree*) f->Get("headTree"); 
       if (!fDecimatedHeadTree) fDecimatedHeadTree = (TTree*) f->Get("headerTree");
-      fDecimatedHeadTree->BuildIndex("event_number"); 
+      fDecimatedHeadTree->BuildIndex("eventNumber"); 
       fDecimatedHeadTree->SetBranchAddress("header",&fHeader); 
       fIndices = ((TTreeIndex*) fDecimatedHeadTree->GetTreeIndex())->GetIndex(); 
     }
@@ -548,7 +548,7 @@ bool  pueo::Dataset::loadRun(int run, DataDirectory dir, bool dec)
 
   if (!fDecimated) fHeadTree->SetBranchAddress("header",&fHeader); 
 
-  fHeadTree->BuildIndex("event_number"); 
+  fHeadTree->BuildIndex("eventNumber"); 
 
   if (!fDecimated) fIndices = ((TTreeIndex*) fHeadTree->GetTreeIndex())->GetIndex(); 
 
@@ -717,7 +717,7 @@ int pueo::Dataset::previousMinBiasEvent()
       fIndex = N() - 1;
     }
     fHeadTree->GetEntry(fIndex);
-    if((fHeader->trig_type&1) == 0) break;
+    if((fHeader->trigType&1) == 0) break;
   }
   
   return nthEvent(fIndex);
@@ -739,7 +739,7 @@ int pueo::Dataset::nextMinBiasEvent()
       fIndex = 0;
     }
     fHeadTree->GetEntry(fIndex);
-    if((fHeader->trig_type&1) == 0) break;
+    if((fHeader->trigType&1) == 0) break;
   }
   
   return nthEvent(fIndex);
@@ -1009,8 +1009,8 @@ int pueo::Dataset::getRunAtTime(double t)
                 run_info  ri; 
                 ri.run = run; 
                 //TODO do this to nanosecond precision 
-                ri.start_time= t->GetMinimum("event_second"); 
-                ri.stop_time = t->GetMaximum("event_second") + 1; 
+                ri.start_time= t->GetMinimum("triggerTime"); 
+                ri.stop_time = t->GetMaximum("triggerTime") + 1; 
                 run_times[version].push_back(ri); 
               }
             }
@@ -1201,13 +1201,13 @@ void pueo::Dataset::overwriteHeader(RawHeader* header, pol::pol_t pol, Int_t fak
 
   // Retain some of the header data for camouflage
   TTimeStamp trigger_time = header->corrected_trigger_time;
-  UInt_t event_number = header->event_number;
+  UInt_t event_number = header->eventNumber;
   Int_t run = header->run;
 
   (*header) = (*fBlindHeader[pol]);
 
   header->corrected_trigger_time = trigger_time;
-  header->event_number = event_number;
+  header->eventNumber = event_number;
   header->run = run;
 
 }

--- a/src/RawHeader.cc
+++ b/src/RawHeader.cc
@@ -25,29 +25,30 @@
 
 int pueo::RawHeader::isInPhiMask(int phi, pueo::pol::pol_t pol) const
 {
-  return phi_trig_mask[pol] & ( 1 << phi); 
+  return phiTrigMask[pol] & ( 1 << phi); 
 }
 
 #ifdef HAVE_PUEORAWDATA
 pueo::RawHeader:: RawHeader(const pueo_full_waveforms_t * wfs):
   run(wfs->run), 
-  event_number(wfs->event),
-  event_second(wfs->event_second),
-  event_time(wfs->event_time),
-  last_pps(wfs->last_pps),
-  llast_pps(wfs->llast_pps),
-  deadtime_counter(wfs->deadtime_counter),
-  deadtime_counter_last_pps(wfs->deadtime_counter_last_pps),
-  deadtime_counter_llast_pps(wfs->deadtime_counter_llast_pps),
-  L2_mask(wfs->L2_mask),
-  readout_time((time_t)wfs->readout_time.utc_secs, wfs->readout_time.utc_nsecs),
+  eventNumber(wfs->event),
+  triggerTime(wfs->event_second),
+  trigTime(wfs->event_time),
+  lastPPS(wfs->last_pps),
+  lastLastPPS(wfs->llast_pps),
+  deadTime(wfs->deadtime_counter),
+  deadTimeLastPPS(wfs->deadtime_counter_last_pps),
+  deadTimeLastLastPPS(wfs->deadtime_counter_llast_pps),
+  L2Mask(wfs->L2_mask),
+  readoutTime(wfs->readout_time.utc_secs),
+  readoutTimeNs(wfs->readout_time.utc_nsecs),
   corrected_readout_time((time_t)0, 0), // cannot know this without post-processing, so initialize to year 1970
   corrected_trigger_time((time_t)0, 0)  // cannot know this without post-processing, so initialize to year 1970
 {
-  if (wfs->soft_trigger) trig_type |= pueo::trigger::kSoft;
-  if (wfs->pps_trigger) trig_type |= pueo::trigger::kPPS0;
-  if (wfs->ext_trigger) trig_type |= pueo::trigger::kExt;
-  if (wfs->L2_mask) trig_type |= pueo::trigger::kRFMI;
+  if (wfs->soft_trigger) trigType |= pueo::trigger::kSoft;
+  if (wfs->pps_trigger)  trigType |= pueo::trigger::kPPS0;
+  if (wfs->ext_trigger)  trigType |= pueo::trigger::kExt;
+  if (wfs->L2_mask)      trigType |= pueo::trigger::kRFMI;
 
   //TODO convert L2 mask ,L1 mask as needed
 }

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -71,9 +71,6 @@ public:
   //                                +----  `triggerTime`, aka `event_second` in libpueorawdata
   //
 
-  [[deprecated("Not populated during raw data conversion nor corrected during post-processing. DO NOT USE.")]]
-  uint32_t triggerTimeNs = 0;///< This was intended to store the subsecond portion of the trigger time.
-
   // Originally a uint32_t in libpueorawdata but int32_t is okay before year 2038.
   // int32_t for easier arithmetics.
   int32_t  triggerTime = 0;  ///< Number of seconds since Unix epoch (1970 Jan 1 00:00:00)

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -46,7 +46,6 @@ public:
   // Initialize all timestamps to a clearly garbage value (year 1970).
   // Otherwise ROOT will initialize them to the current time and that's not a good obvious garbage value
   RawHeader():
-    readout_time((time_t)0,0),
     corrected_readout_time((time_t)0,0),
     corrected_trigger_time((time_t)0,0)
   {;}
@@ -54,46 +53,75 @@ public:
 #ifdef HAVE_PUEORAWDATA
   RawHeader(const pueo_full_waveforms_t * wfs);
 #endif
-  uint32_t   run = 0; ///< Run number, assigned on ground
-  uint32_t   event_number = 0;
+  uint32_t run = 0; ///< Run number
+  uint32_t eventNumber = 0;
 
-  /* An example:
+  // Definitions of last_pps, event_time, and event_second.
+  // For details see DocDB doc-607-v5 (https://pueo.uchicago.edu/DocDB/cgi-bin/ShowDocument?docid=607)
+  // note that example values are for illustration purposes only: [sec] is usually very large
+  //
+  //                `lastPPS`-------+       +-------- `trigTime`, aka `event_time` in libpueorawdata
+  //                                ↓       ↓      
+  //        0--------125E6--------250E6-----o--375E6--------500E6--------625E6-------->
+  //        |                               |                                    [TURF clock ticks]
+  //     Run Start                       trigger!
+  //        |                               |                                    [sec]
+  //       111--------112----------113----------114----------115----------116---------->
+  //                                ↑
+  //                                +----  `triggerTime`, aka `event_second` in libpueorawdata
+  //
 
-            `last_pps`-------+       +-------- `event_time`
-                             ↓       ↓      
-     0--------125E6--------250E6-----o--375E6--------500E6--------625E6-------->
-     |                               |                                    [TURF clock ticks]
-  Run Start                       trigger!
-     |                               |                                    [sec]
-    111--------112----------113----------114----------115----------116---------->
-                             ↑
-          `event_second` ----+        
+  [[deprecated("Not populated during raw data conversion nor corrected during post-processing. DO NOT USE.")]]
+  uint32_t triggerTimeNs = 0;///< This was intended to store the subsecond portion of the trigger time.
 
-  */
-  int32_t    event_second = 0; ///< Originally a uint32_t in libpueorawdata but int32_t is okay before year 2038
-                               ///< Value can be wrong prior to post-processing.
+  // Originally a uint32_t in libpueorawdata but int32_t is okay before year 2038.
+  // int32_t for easier arithmetics.
+  int32_t  triggerTime = 0;  ///< Number of seconds since Unix epoch (1970 Jan 1 00:00:00)
+                             ///< This stores the ORIGINAL RAW DATA VALUE WHICH CAN BE WRONG prior to post-processing.
+                             ///< The corrected value is stored in `corrected_trigger_time`.
 
-  uint32_t   event_time = 0; ///< 32-bit free running TURF clock value very briefly after trigger.
-  uint32_t   last_pps = 0; ///< TURF clock value at `event_second`. Value can be wrong prior to post-processing.
-  uint32_t   llast_pps = 0; ///< ... one second prior, value can be wrong, won't be corrected
-  uint32_t   deadtime_counter = 0; ///< @todo: no idea what these are, need help documenting
-  uint32_t   deadtime_counter_last_pps = 0;
-  uint32_t   deadtime_counter_llast_pps = 0;
-  uint32_t   L2_mask = 0;
-  uint32_t   trig_type = 0; ///< soft, pps, or ext trigger (see also pueo::trigger in Conventions.h)
-  TTimeStamp readout_time; ///< Time since Unix epoch [sec]
-                           ///< Tagged by the flight computer upon packet creation (ie event reception)
+  uint32_t trigTime = 0;     ///< 32-bit free running TURF clock value very briefly after trigger.
+
+  uint32_t lastPPS = 0;      ///< TURF clock value at the nearest prior second (ie. at `triggerTime`).
+                             ///< The variable stores the ORIGINAL RAW DATA VALUE WHICH CAN BE WRONG.
+                             ///< The corrected value is stored in `corrected_pps`.
+
+  double   corrected_pps = 0;///< corrected `lastPPS` from post-processing.
+
+  double   clock_frequency = 0; ///< Obtained from post-processing: average pps difference b/w each second.
+                                ///< Nominal value is about 125MHz.
+                                ///< The subsecond is (trigTime - lastPPS) / clock_frequency
+                                ///< The subsecond will be stored in `corrected_trigger_time`
+
+  uint32_t lastLastPPS = 0;  ///< Same as `lastPPS` but one second prior; not corrected.
+
+  uint32_t deadTime = 0;     ///< @todo: no idea what these are, need help documenting
+  uint32_t deadTimeLastPPS = 0;
+  uint32_t deadTimeLastLastPPS = 0;
+  uint32_t L2Mask = 0;
+
+  uint32_t trigType = 0;    ///< soft, pps, or ext trigger (see also pueo::trigger in Conventions.h)
+
+  int32_t  readoutTime = 0;  ///< Number of seconds since Unix epoch (1970 Jan 1 00:00:00)
+                             ///< Tagged by the flight computer upon packet creation (ie event reception)
+                             ///< This stores the original raw-data value,
+                             ///< which can drift and is accurate to only a few seconds.
+                             ///< Prefer `corrected_trigger_time` for timing.
+
+  uint32_t readoutTimeNs = 0;///< Subsecond portion of the readout time [nanosec]
+                             ///< This stores the original raw-data value, likely not trust-worthy.
 
   TTimeStamp corrected_readout_time; ///< correction via post-processing (method TBD)
+
   TTimeStamp corrected_trigger_time; ///< correction via post-processing with pueo::Timemark
-                                     ///< second: from (corrected) `event_second`
-                                     ///< nanosecond: from `event_time` and (corrected) `last_pps`
+                                     ///< second: from (corrected) `triggerTime`
+                                     ///< nanosecond: from `trigTime`, `corrected_last_pps` and `clock_frequency`
 
   uint32_t  flags = 0; /// @todo: not implemented yet (2026Apr2)
   uint8_t   L1_octants[k::NUM_SURF_SLOTS] ={0}; ///< @todo not implemented yet (2026Apr2)
-  uint32_t  phi_trig_mask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) 
-                                              ///< @note: not quite the same as L2_mask
-                                              ///< @todo: not implemented yet (2026Apr2)
+  uint32_t  phiTrigMask[k::NUM_POLS] = {0}; ///< 24-bit phi mask (from TURF) 
+                                            ///< @note: not quite the same as L2_mask
+                                            ///< @todo: not implemented yet (2026Apr2)
 
   // Trigger info
   int isInPhiMask(int phi, pol::pol_t=pol::kVertical) const; ///< Returns 1 if given phi-pol is in mask

--- a/src/pueo/RawHeader.h
+++ b/src/pueo/RawHeader.h
@@ -92,9 +92,15 @@ public:
 
   uint32_t lastLastPPS = 0;  ///< Same as `lastPPS` but one second prior; not corrected.
 
-  uint32_t deadTime = 0;     ///< @todo: no idea what these are, need help documenting
-  uint32_t deadTimeLastPPS = 0;
-  uint32_t deadTimeLastLastPPS = 0;
+  uint32_t deadTime = 0;     ///< Cumulative dead time up until `trigTime` [units: TURF clock ticks]
+                             ///< aka dead_time_counter in `rawdata.h`
+
+  uint32_t deadTimeLastPPS = 0; ///< Cumulative dead time up until the most recent GPS second
+                                ///< aka `dead_time_counter_last_pps` in `rawdata.h`
+                                ///< aka `last_dead` in `DawHsk.h`
+
+  uint32_t deadTimeLastLastPPS = 0; ///< Same as `deadTimeLastPPS` but one GPS second prior.
+  
   uint32_t L2Mask = 0;
 
   uint32_t trigType = 0;    ///< soft, pps, or ext trigger (see also pueo::trigger in Conventions.h)


### PR DESCRIPTION
- Partially reverts #13, so in the end with version 4 of `pueo::RawHeader` the net changes are
   1. `L1Octants` -> `L1_octants`, this change shouldn't have any impact since this field hasn't been implemented at all yet.
   2. `triggerTimeNs` removed, since it's never populated during raw data conversion, and it will not be populated after post processing either, since we store the corrected time stamp in `corrected_trigger_time`.
- manual schema evolution removed as its no longer needed
- corresponding: [pueoSim 107](https://github.com/PUEOCollaboration/pueoSim/pull/107)